### PR TITLE
VET-60: Harden and add optional proxy class

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ include ::profile_ansible
 ## Usage
 
 You will need to provide the following parameters:
-* `authorized_keys`
 * `control_nodelist`
+
+`control_nodelist` is a Hash containing per-node `address` and `authroized_keys`.
+Refer to [REFERENCE.md](REFERENCE.md) for an example.
 
 ## Dependencies
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,6 +7,7 @@
 ### Classes
 
 * [`profile_ansible`](#profile_ansible): Setup local ansible user
+* [`profile_ansible::proxy`](#profile_ansible--proxy): Setup optional proxy user and config for ansible access
 
 ## Classes
 
@@ -27,7 +28,6 @@ include profile_ansible
 The following parameters are available in the `profile_ansible` class:
 
 * [`username`](#-profile_ansible--username)
-* [`authorized_keys`](#-profile_ansible--authorized_keys)
 * [`control_nodelist`](#-profile_ansible--control_nodelist)
 * [`sshd_custom_cfg`](#-profile_ansible--sshd_custom_cfg)
 * [`sudo_custom_cfg`](#-profile_ansible--sudo_custom_cfg)
@@ -38,20 +38,11 @@ Data type: `String`
 
 Username that ansible controller will connect as
 
-##### <a name="-profile_ansible--authorized_keys"></a>`authorized_keys`
+##### <a name="-profile_ansible--control_nodelist"></a>`control_nodelist`
 
 Data type: `Hash`
 
-Hash of keys to be used by puppetlabs-sshkeys_core
-See https://forge.puppet.com/modules/puppetlabs/sshkeys_core
-The 'user' parameter can be omitted as it uses $username
-
-##### <a name="-profile_ansible--control_nodelist"></a>`control_nodelist`
-
-Data type: `Array[String, 1]`
-
-Array of IP addresses of the Ansible control nodes
-Login access for this user is limited to these IP addresses
+Hash keyed by control node hostname, containing address and authorized_keys
 
 ##### <a name="-profile_ansible--sshd_custom_cfg"></a>`sshd_custom_cfg`
 
@@ -64,4 +55,42 @@ Custom sshd configuration options for this user
 Data type: `String`
 
 Custom sudo configuration options for this user
+
+### <a name="profile_ansible--proxy"></a>`profile_ansible::proxy`
+
+Setup an optional proxy user that Ansible control nodes can use as a jump host for SSH port forwarding.
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_ansible::proxy
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_ansible::proxy` class:
+
+* [`username`](#-profile_ansible--proxy--username)
+* [`nodelist`](#-profile_ansible--proxy--nodelist)
+* [`sshd_custom_cfg`](#-profile_ansible--proxy--sshd_custom_cfg)
+
+##### <a name="-profile_ansible--proxy--username"></a>`username`
+
+Data type: `String`
+
+Username that ansible proxy will connect as
+
+##### <a name="-profile_ansible--proxy--nodelist"></a>`nodelist`
+
+Data type: `Hash`
+
+Hash keyed by proxy node hostname, containing address and authorized_keys
+
+##### <a name="-profile_ansible--proxy--sshd_custom_cfg"></a>`sshd_custom_cfg`
+
+Data type: `Hash`
+
+Custom sshd configuration options for this user
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,23 +1,62 @@
 ---
-profile_ansible::username: "ansible"
-profile_ansible::authorized_keys:
-  ansible@localhost:
-    type: "ssh-rsa"
-    key: "REPLACE_ME_WITH_VALID_SSH_PUBLIC_KEY"  # MUST be overridden in environment-specific Hiera data for production
 profile_ansible::control_nodelist:
-  - "127.0.0.1"  # TODO: Set to actual Ansible control node IP addresses
+  # MUST BE OVERRIDDEN IN ENVIRONMENT-SPECIFIC DATA
+  localhost:  # SET TO ACTUAL ANSIBLE CONTROL NODE HOSTNAME AND DATA
+    address: "127.0.0.1"
+    authorized_keys:
+      ansible@localhost:
+        type: "ssh-ed25519"
+        key: "REPLACE_ME_WITH_VALID_SSH_PUBLIC_KEY"
 profile_ansible::sshd_custom_cfg:
+  AllowAgentForwarding: "no"
+  AllowTcpForwarding: "no"
   AuthenticationMethods: "publickey"
   Banner: "none"
-  DisableForwarding: "no"
+  ClientAliveCountMax: "0"
+  ClientAliveInterval: "300"
+  DisableForwarding: "yes"
+  GatewayPorts: "no"
   GSSAPIAuthentication: "no"
   KerberosAuthentication: "no"
-  MaxAuthTries: "6"
-  MaxSessions: "10"
+  MaxAuthTries: "2"
+  MaxSessions: "4"
   PasswordAuthentication: "no"
+  PermitTTY: "no"
+  PermitTunnel: "no"
   PubkeyAuthentication: "yes"
   X11Forwarding: "no"
 profile_ansible::sudo_custom_cfg: |
   Defaults:%{lookup('profile_ansible::username')} !mail_always
   Defaults:%{lookup('profile_ansible::username')} !requiretty
+  Defaults:%{lookup('profile_ansible::username')} secure_path="/usr/sbin:/usr/bin:/sbin:/bin"
   %{lookup('profile_ansible::username')} ALL=(ALL) NOPASSWD: NOMAIL: ALL
+profile_ansible::username: "ansible"
+
+profile_ansible::proxy::username: "ansible-proxy"
+profile_ansible::proxy::nodelist:
+  # MUST BE OVERRIDDEN IN ENVIRONMENT-SPECIFIC DATA
+  localhost:  # SET TO ACTUAL ANSIBLE CONTROL NODE HOSTNAME AND DATA
+    address: "127.0.0.1"
+    authorized_keys:
+      ansible@localhost:
+        type: "ssh-ed25519"
+        key: "REPLACE_ME_WITH_VALID_SSH_PUBLIC_KEY"
+profile_ansible::proxy::sshd_custom_cfg:
+  AllowAgentForwarding: "no"
+  AllowTcpForwarding: "yes"
+  AuthenticationMethods: "publickey"
+  Banner: "none"
+  DisableForwarding: "no"
+  ForceCommand: "/usr/sbin/nologin"
+  GSSAPIAuthentication: "no"
+  KbdInteractiveAuthentication: "no"
+  KerberosAuthentication: "no"
+  LogLevel: "VERBOSE"
+  MaxAuthTries: "1"
+  MaxSessions: "10"
+  PasswordAuthentication: "no"
+  # PermitOpen 10.0.0.0/8:22  # RESTRICT WHERE IT CAN JUMP TO
+  PermitTTY: "no"
+  PermitTunnel: "no"
+  PubkeyAuthentication: "yes"
+  X11Forwarding: "no"

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -1,34 +1,30 @@
-# @summary Setup local ansible user
+# @summary Setup optional proxy user and config for ansible access
 #
-# Setup a local ansible user that Ansible control node can connect as.
+# Setup an optional proxy user that Ansible control nodes can use as a jump host for SSH port forwarding.
 #
 # @param username
-#   Username that ansible controller will connect as
+#   Username that ansible proxy will connect as
 #
-# @param control_nodelist
-#   Hash keyed by control node hostname, containing address and authorized_keys
+# @param nodelist
+#   Hash keyed by proxy node hostname, containing address and authorized_keys
 #
 # @param sshd_custom_cfg
 #   Custom sshd configuration options for this user
 #
-# @param sudo_custom_cfg
-#   Custom sudo configuration options for this user
-#
 # @example
-#   include profile_ansible
-class profile_ansible (
-  Hash   $control_nodelist,
+#   include profile_ansible::proxy
+class profile_ansible::proxy (
+  Hash   $nodelist,
   Hash   $sshd_custom_cfg,
-  String $sudo_custom_cfg,
   String $username,
 ) {
   # ENSURE THE USER EXISTS
   user { $username:
     ensure     => present,
-    comment    => 'Ansible client user',
+    comment    => 'Ansible proxy user',
     forcelocal => true,
     managehome => true,
-    shell      => '/bin/bash',
+    shell      => '/usr/sbin/nologin',
     password   => '!!',
   }
 
@@ -46,27 +42,27 @@ class profile_ansible (
   # STATIC HARDENING OPTIONS APPLIED TO ALL KEYS
   $auth_key_security_options = [
     'no-agent-forwarding',
-    'no-port-forwarding',
     'no-pty',
     'no-X11-forwarding',
+    'command="/usr/sbin/nologin"',
   ]
 
   # BUILD EACH authorized_keys LINE
-  $authorized_lines = $control_nodelist.map |String $node_name, Hash $node_data| {
+  $authorized_lines = $nodelist.map |String $node_name, Hash $node_data| {
     # VALIDATE: address MUST BE A SINGLE STRING
     if $node_data['address'] !~ String {
-      fail("${module_name}::init: node '${node_name}' must have exactly one 'address' as String")
+      fail("${module_name}::proxy: node '${node_name}' must have exactly one 'address' as String")
     }
     $address       = $node_data['address']
     $options_field = (["from=\"${address}\""] + $auth_key_security_options).join(',')
     # VALIDATE KEYS
     if $node_data['authorized_keys'] !~ Hash {
-      fail("${module_name}::init: node '${node_name}' is missing 'authorized_keys' Hash")
+      fail("${module_name}::proxy: node '${node_name}' is missing 'authorized_keys' Hash")
     }
     # PRODUCE ONE LINE PER KEY FOR THIS NODE
     $node_data['authorized_keys'].map |String $key_id, Hash $key_data| {
       if $key_data['type'] == undef or $key_data['key'] == undef {
-        fail("${module_name}::init: ${node_name}/${key_id} missing 'type' or 'key'")
+        fail("${module_name}::proxy: ${node_name}/${key_id} missing 'type' or 'key'")
       }
       $comment = $key_data['comment'] ? {
         String => $key_data['comment'],
@@ -88,9 +84,6 @@ class profile_ansible (
     require => File["/home/${username}/.ssh"],
   }
 
-  # Collect addresses -> flatten -> dedupe
-  $control_node_ips = unique(flatten($control_nodelist.map |$n, $d| { $d['address'] }))
-
   pam_access::entry { "Disable tty access for ${username}":
     user       => $username,
     origin     => 'tty',
@@ -98,23 +91,13 @@ class profile_ansible (
     position   => '-1',
   }
 
-  sshd::allow_from { 'sshd allow from Ansible control nodes':
-    hostlist                => $control_node_ips,
+  # Collect addresses -> flatten -> dedupe
+  $node_ips = unique(flatten($nodelist.map |$n, $d| { $d['address'] }))
+
+  sshd::allow_from { 'sshd allow from Ansible proxy nodes':
+    hostlist                => $node_ips,
     users                   => [$username],
     groups                  => [$username],
     additional_match_params => $sshd_custom_cfg,
-  }
-
-  pam_access::entry { "Allow sudo for ${username}":
-    user       => $username,
-    origin     => 'LOCAL',
-    permission => '+',
-    position   => '-1',
-  }
-
-  sudo::conf { "sudo_for_${username}":
-    ensure   => 'present',
-    priority => 10,
-    content  => $sudo_custom_cfg,
   }
 }

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_ansible::proxy' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+    end
+  end
+end

--- a/templates/authorized_keys.epp
+++ b/templates/authorized_keys.epp
@@ -1,0 +1,4 @@
+# Managed by Puppet — DO NOT EDIT
+<% $authorized_lines.each |$line| { -%>
+<%= $line %>
+<% } -%>


### PR DESCRIPTION
Fix issue #3.

```
Refactor control_nodelist to specify authorized keys per node
Add optional proxy class
Harden sshd configs
Harden ansible sudo config
Set pam access to disable tty for ansible users
Convert authorized_keys entries to be a template
```

Tested on:
- `asd-prov01`
- `cc-adm01`
- `dt-prov03`